### PR TITLE
Add support for sync and updateListStatus endpoints

### DIFF
--- a/src/Resources/ActiveCampaignContactsResource.php
+++ b/src/Resources/ActiveCampaignContactsResource.php
@@ -88,6 +88,50 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     }
 
     /**
+     * Create a contact or update an existing contact and return the ID.
+     *
+     * @see https://developers.activecampaign.com/reference/sync-a-contacts-data
+     *
+     * @throws ActiveCampaignException
+     */
+    public function sync(string $email, array $attributes = []): ActiveCampaignContact
+    {
+        return ContactFactory::make($this->request(
+            method: 'post',
+            path: 'contact/sync',
+            data: [
+                'contact' => [
+                    'email' => $email,
+                ] + $attributes,
+            ],
+            responseKey: 'contact'
+        ));
+    }
+
+    /**
+     * Subscribe a contact to a list or unsubscribe a contact from a list.
+     *
+     * @see https://developers.activecampaign.com/reference/update-list-status-for-contact
+     *
+     * @throws ActiveCampaignException
+     */
+    public function updateListStatus(int $contactId, int $listId, int $status): ActiveCampaignContact
+    {
+        return ContactFactory::make($this->request(
+            method: 'post',
+            path: 'contact/sync',
+            data: [
+                'contactList' => [
+                    'list' => $listId,
+                    'contact' => $contactId,
+                    'status' => $status,
+                ],
+            ],
+            responseKey: 'contact'
+        ));
+    }
+
+    /**
      * Delete an existing contact by their id.
      *
      *


### PR DESCRIPTION
This adds the [`sync()`](https://developers.activecampaign.com/reference/sync-a-contacts-data) and [`updateListStatus()`](https://developers.activecampaign.com/reference/update-list-status-for-contact) methods to `ActiveCampaignContactsResource`.