### PR TITLE
Normalise docblocks and add API references.

### DIFF
--- a/src/Resources/ActiveCampaignContactsResource.php
+++ b/src/Resources/ActiveCampaignContactsResource.php
@@ -10,7 +10,11 @@ use Label84\ActiveCampaign\Factories\ContactFactory;
 class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
 {
     /**
-     * Retreive an existing contact by their id.
+     * Retrieve an existing contact by their ID.
+     *
+     * @see https://developers.activecampaign.com/reference/get-contact
+     *
+     * @throws ActiveCampaignException
      */
     public function get(int $id): ActiveCampaignContact
     {
@@ -24,9 +28,13 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * List all contact, search contacts, or filter contacts by query defined criteria.
+     * List all contacts, search contacts, or filter contacts by query defined criteria.
+     *
+     * @see https://developers.activecampaign.com/reference/list-all-contacts
      *
      * @return Collection<int, ActiveCampaignContact>
+     *
+     * @throws ActiveCampaignException
      */
     public function list(?string $query = ''): Collection
     {
@@ -41,8 +49,9 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Create a contact and get the contact id.
+     * Create a contact and return the contact ID.
      *
+     * @see https://developers.activecampaign.com/reference/create-a-new-contact
      *
      * @throws ActiveCampaignException
      */
@@ -65,6 +74,7 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     /**
      * Update an existing contact.
      *
+     * @see https://developers.activecampaign.com/reference/update-a-contact-new
      *
      * @throws ActiveCampaignException
      */
@@ -88,8 +98,9 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Delete an existing contact by their id.
+     * Delete an existing contact by their ID.
      *
+     * @see https://developers.activecampaign.com/reference/delete-contact
      *
      * @throws ActiveCampaignException
      */
@@ -128,7 +139,7 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
     /**
      * Remove a tag from a contact.
      *
-     * @see https://developers.activecampaign.com/reference#delete-contact-tag
+     * @see https://developers.activecampaign.com/reference/remove-a-contacts-tag
      *
      * @throws ActiveCampaignException
      */

--- a/src/Resources/ActiveCampaignFieldValuesResource.php
+++ b/src/Resources/ActiveCampaignFieldValuesResource.php
@@ -9,8 +9,9 @@ use Label84\ActiveCampaign\Factories\FieldValueFactory;
 class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
 {
     /**
-     * Retreive an existing field value by their id.
+     * Retrieve an existing field value by its ID.
      *
+     * @see https://developers.activecampaign.com/reference/retrieve-a-fieldvalues
      *
      * @throws ActiveCampaignException
      */
@@ -26,8 +27,9 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Create a field value and get the id.
+     * Create a field value and return its ID.
      *
+     * @see https://developers.activecampaign.com/reference/create-fieldvalue
      *
      * @throws ActiveCampaignException
      */
@@ -52,6 +54,7 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
     /**
      * Update an existing field value.
      *
+     * @see https://developers.activecampaign.com/reference/update-a-custom-field-value-for-contact
      *
      * @throws ActiveCampaignException
      */
@@ -74,8 +77,9 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Delete an existing field value by their id.
+     * Delete an existing field value by its ID.
      *
+     * @see https://developers.activecampaign.com/reference/delete-a-fieldvalue-1
      *
      * @throws ActiveCampaignException
      */

--- a/src/Resources/ActiveCampaignTagsResource.php
+++ b/src/Resources/ActiveCampaignTagsResource.php
@@ -10,8 +10,9 @@ use Label84\ActiveCampaign\Factories\TagFactory;
 class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
 {
     /**
-     * Retreive an existing tag by their id.
+     * Retrieve an existing tag by its ID.
      *
+     * @see https://developers.activecampaign.com/reference/retrieve-a-tag
      *
      * @throws ActiveCampaignException
      */
@@ -27,7 +28,9 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * List all tags filtered by name
+     * List all tags, optionally filtering them by name
+     *
+     * @see https://developers.activecampaign.com/reference/retrieve-all-tags
      *
      * @return Collection<int, ActiveCampaignTag>
      *
@@ -46,8 +49,9 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Create a tag and get the id.
+     * Create a tag and return its ID.
      *
+     * @see https://developers.activecampaign.com/reference/create-a-new-tag
      *
      * @throws ActiveCampaignException
      */
@@ -72,6 +76,7 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
     /**
      * Update an existing tag.
      *
+     * @see https://developers.activecampaign.com/reference/update-a-tag
      *
      * @throws ActiveCampaignException
      */
@@ -94,8 +99,9 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
     }
 
     /**
-     * Delete an existing tag by their id.
+     * Delete an existing tag by its ID.
      *
+     * @see https://developers.activecampaign.com/reference/delete-a-tag
      *
      * @throws ActiveCampaignException
      */


### PR DESCRIPTION
This adds references to the current V3 docs to all the ActiveCampaign*Resource methods, adds @throws annotations where they were missing and normalises the descriptions to those used in the AC docs.