### PR TITLE
Fix endpoints that don't match the API docs and fix static analysis errors

### DIFF
--- a/src/Resources/ActiveCampaignContactsResource.php
+++ b/src/Resources/ActiveCampaignContactsResource.php
@@ -14,13 +14,11 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
      */
     public function get(int $id): ActiveCampaignContact
     {
-        $contact = $this->request(
+        return ContactFactory::make($this->request(
             method: 'get',
             path: 'contacts/'.$id,
             responseKey: 'contact'
-        );
-
-        return ContactFactory::make($contact);
+        ));
     }
 
     /**
@@ -70,7 +68,7 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
      */
     public function update(ActiveCampaignContact $contact): ActiveCampaignContact
     {
-        $contact = $this->request(
+        return ContactFactory::make($this->request(
             method: 'put',
             path: 'contacts/'.$contact->id,
             data: [
@@ -82,9 +80,7 @@ class ActiveCampaignContactsResource extends ActiveCampaignBaseResource
                 ],
             ],
             responseKey: 'contact'
-        );
-
-        return ContactFactory::make($contact);
+        ));
     }
 
     /**

--- a/src/Resources/ActiveCampaignFieldValuesResource.php
+++ b/src/Resources/ActiveCampaignFieldValuesResource.php
@@ -29,7 +29,7 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
      *
      * @throws ActiveCampaignException
      */
-    public function create(int $contactId, string $field, string $value): string
+    public function create(int $contactId, string $fieldId, string $value, bool $useDefaults = true): string
     {
         $fieldValue = $this->request(
             method: 'post',
@@ -37,9 +37,10 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
             data: [
                 'fieldValue' => [
                     'contact' => $contactId,
-                    'field' => $field,
+                    'field' => $fieldId,
                     'value' => $value,
                 ],
+                'useDefaults' => $useDefaults,
             ],
             responseKey: 'contact'
         );
@@ -57,7 +58,7 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
     {
         return FieldValueFactory::make($this->request(
             method: 'put',
-            path: 'fieldValues/'.$fieldValue->contactId,
+            path: 'fieldValues/'.$fieldValue->field,
             data: [
                 'fieldValue' => [
                     'contact' => $fieldValue->contactId,

--- a/src/Resources/ActiveCampaignFieldValuesResource.php
+++ b/src/Resources/ActiveCampaignFieldValuesResource.php
@@ -16,13 +16,11 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
      */
     public function get(int $id): ActiveCampaignFieldValue
     {
-        $fieldValue = $this->request(
+        return FieldValueFactory::make($this->request(
             method: 'get',
             path: 'fieldValues/'.$id,
             responseKey: 'fieldValue'
-        );
-
-        return FieldValueFactory::make($fieldValue);
+        ));
     }
 
     /**
@@ -57,7 +55,7 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
      */
     public function update(ActiveCampaignFieldValue $fieldValue): ActiveCampaignFieldValue
     {
-        $fieldValue = $this->request(
+        return FieldValueFactory::make($this->request(
             method: 'put',
             path: 'fieldValues/'.$fieldValue->contactId,
             data: [
@@ -68,9 +66,7 @@ class ActiveCampaignFieldValuesResource extends ActiveCampaignBaseResource
                 ],
             ],
             responseKey: 'fieldValue'
-        );
-
-        return FieldValueFactory::make($fieldValue);
+        ));
     }
 
     /**

--- a/src/Resources/ActiveCampaignTagsResource.php
+++ b/src/Resources/ActiveCampaignTagsResource.php
@@ -77,7 +77,7 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
      */
     public function update(ActiveCampaignTag $tag): ActiveCampaignTag
     {
-        $tag = $this->request(
+        return TagFactory::make($this->request(
             method: 'put',
             path: 'tags/'.$tag->id,
             data: [
@@ -88,9 +88,7 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
                 ],
             ],
             responseKey: 'tag'
-        );
-
-        return TagFactory::make($tag);
+        ));
     }
 
     /**

--- a/src/Resources/ActiveCampaignTagsResource.php
+++ b/src/Resources/ActiveCampaignTagsResource.php
@@ -82,9 +82,9 @@ class ActiveCampaignTagsResource extends ActiveCampaignBaseResource
             path: 'tags/'.$tag->id,
             data: [
                 'tag' => [
-                    'id' => $tag->id,
                     'tag' => $tag->name,
                     'description' => $tag->description,
+                    'tagType' => 'contact',
                 ],
             ],
             responseKey: 'tag'


### PR DESCRIPTION
The change to the `update()` method in e8285df is potentially a breaking change, but the current method is broken and will not update the correct resource.

The ActiveCampaignFieldValuesResource::update() method currently uses the contact ID in the URL, [instead of the field value ID](https://developers.activecampaign.com/reference/update-a-custom-field-value-for-contact), so if used it will change the wrong field value, or fail if no field value exists with a matching ID.

Commit 2c5ad3e inlines the temporary variables used in methods that accept one of the DataObjects and return the same using a factory on the response. Currently the data object that is typehint as the data object is reused to store the response array, causing warnings in static analysers.