### PR TITLE
Throw ActiveCampaignException instead of RequestException on HTTP error

### DIFF
--- a/src/Exceptions/ActiveCampaignException.php
+++ b/src/Exceptions/ActiveCampaignException.php
@@ -2,9 +2,9 @@
 
 namespace Label84\ActiveCampaign\Exceptions;
 
-use Exception;
+use Illuminate\Http\Client\RequestException;
 
-class ActiveCampaignException extends Exception
+class ActiveCampaignException extends RequestException
 {
     //
 }

--- a/src/Resources/ActiveCampaignBaseResource.php
+++ b/src/Resources/ActiveCampaignBaseResource.php
@@ -3,6 +3,7 @@
 namespace Label84\ActiveCampaign\Resources;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Label84\ActiveCampaign\ActiveCampaignService;
 use Label84\ActiveCampaign\Exceptions\ActiveCampaignException;
@@ -17,15 +18,18 @@ class ActiveCampaignBaseResource
         $this->client = $this->service->makeRequest();
     }
 
+    /**
+     * @throws ActiveCampaignException
+     */
     public function request(string $method, string $path, array $data = [], ?string $responseKey = null): array
     {
-        /** @var Response $response */
-        $response = $this->client->$method($path, $data);
+        try {
+            /** @var Response $response */
+            $response = $this->client->$method($path, $data);
 
-        if ($response->failed()) {
-            throw new ActiveCampaignException($response->json());
+            return $response->throw()->json($responseKey);
+        } catch (RequestException $exception) {
+            throw new ActiveCampaignException($exception->response);
         }
-
-        return $response->throw()->json($responseKey);
     }
 }


### PR DESCRIPTION
This refactors  `ActiveCampaignBaseResource::request()`  to take advantage of the `throw()` method already being used to ensure `ActiveCampaignException` is thrown. It extends `ActiveCampaignException` from the `RequestException` to maintain the `response` functionality.