### PR TITLE
PendingRequest::get() - $data must be null if query string is used

### DIFF
--- a/src/Resources/ActiveCampaignBaseResource.php
+++ b/src/Resources/ActiveCampaignBaseResource.php
@@ -21,8 +21,12 @@ class ActiveCampaignBaseResource
     /**
      * @throws ActiveCampaignException
      */
-    public function request(string $method, string $path, array $data = [], ?string $responseKey = null): array
+    public function request(string $method, string $path, ?array $data = [], ?string $responseKey = null): array
     {
+        if ($data === [] && $method === 'get') {
+            $data = null;
+        }
+
         try {
             /** @var Response $response */
             $response = $this->client->$method($path, $data);


### PR DESCRIPTION
Passing an empty array instead of null on PendingRequest::get() causes it to remove all query strings already attached to $path.

Fixes #7